### PR TITLE
trusty: Add image based on ubuntu trusty

### DIFF
--- a/base-ubuntu-trusty/Dockerfile.gcc
+++ b/base-ubuntu-trusty/Dockerfile.gcc
@@ -1,0 +1,9 @@
+# Base from Ubuntu trusty
+FROM ubuntu:trusty
+
+# The docker build process is noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Run the install process using the provided script
+COPY scripts/ /scripts/
+RUN /scripts/dockerfile_gcc.sh

--- a/base-ubuntu-trusty/build.sh
+++ b/base-ubuntu-trusty/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# Build gcc image
+docker build -f Dockerfile.gcc \
+             -t curlimages/base-ubuntu-trusty:gcc \
+             .

--- a/base-ubuntu-trusty/push.sh
+++ b/base-ubuntu-trusty/push.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# Push docker image. This assumes that the curlimages user is logged in.
+docker push curlimages/base-ubuntu-trusty:gcc

--- a/base-ubuntu-trusty/scripts/dockerfile_gcc.sh
+++ b/base-ubuntu-trusty/scripts/dockerfile_gcc.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Print out debug info and fail if a sub-step fails
+set -exuo pipefail
+
+# Define a set of temporary docker packages used during docker building.
+DOCKER_BUILD_PACKAGES="software-properties-common curl"
+
+# Update APT so we can install packages.
+apt-get -y update
+
+# Install temporary build packages
+apt-get -y install $DOCKER_BUILD_PACKAGES
+
+# Install the necessary repositories:
+# - ubuntu-toolchain-r-test
+add-apt-repository ppa:ubuntu-toolchain-r/test
+
+# Install all necessary packages for curl building
+apt-get -y update
+bash /scripts/install_common.sh
+apt-get -y install gcc-7 g++-7
+
+# Install gcc-7 as the standard cc and g++-7 as the standard c++
+update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 10
+update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 10
+update-alternatives --install /usr/bin/cc cc /usr/bin/gcc 30
+update-alternatives --set cc /usr/bin/gcc
+update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 30
+update-alternatives --set c++ /usr/bin/g++
+
+# Download, compile and install other libraries.
+/scripts/install_nghttp2.sh
+/scripts/install_libidn2.sh
+/scripts/install_libpsl.sh
+
+# Remove the temporary build packages and any auto-installed dependencies
+apt-get --purge -y remove $DOCKER_BUILD_PACKAGES
+apt-get -y autoremove
+
+# Removing any apt cache data.
+rm -rf /var/lib/apt/lists/*

--- a/base-ubuntu-trusty/scripts/install_common.sh
+++ b/base-ubuntu-trusty/scripts/install_common.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Install common dependencies
+apt-get -y install make \
+                   pkg-config \
+                   autoconf \
+                   libtool \
+                   valgrind \
+                   libev-dev \
+                   libc-ares-dev \
+                   libstdc++-7-dev \
+                   stunnel4 \
+                   libssh2-1-dev \
+                   libssh-dev \
+                   krb5-user \
+                   autopoint \
+                   libunistring-dev \
+                   python

--- a/base-ubuntu-trusty/scripts/install_libidn2.sh
+++ b/base-ubuntu-trusty/scripts/install_libidn2.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+# Download, compile and install libidn2.
+pushd /tmp
+curl -L https://ftp.gnu.org/gnu/libidn/libidn2-2.0.4.tar.gz | tar -xzvf -
+pushd libidn2-2.0.4
+./configure --prefix=/usr
+make
+make install
+popd
+
+# Clean up afterwards.
+rm -rf libidn2-2.0.4
+popd

--- a/base-ubuntu-trusty/scripts/install_libpsl.sh
+++ b/base-ubuntu-trusty/scripts/install_libpsl.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+# Download, compile and install libpsl.
+pushd /tmp
+curl -L https://github.com/rockdaboot/libpsl/releases/download/libpsl-0.20.1/libpsl-0.20.1.tar.gz | tar -xzvf -
+pushd libpsl-0.20.1
+autoreconf -i
+./configure --prefix=/usr
+make
+make install
+popd
+
+# Clean up afterwards.
+rm -rf libpsl-0.20.1
+popd

--- a/base-ubuntu-trusty/scripts/install_nghttp2.sh
+++ b/base-ubuntu-trusty/scripts/install_nghttp2.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+apt-get install -y libcunit1-dev \
+                   libjemalloc-dev
+
+# Download, compile and install nghttp2.
+pushd /tmp
+curl -L https://github.com/nghttp2/nghttp2/releases/download/v1.24.0/nghttp2-1.24.0.tar.gz | tar xzvf -
+pushd nghttp2-1.24.0
+./configure --prefix=/usr --disable-threads --enable-app
+make
+make install
+popd
+
+# Clean up afterwards.
+rm -rf nghttp2-1.24.0
+popd


### PR DESCRIPTION
Using ubuntu trusty, come up with a reasonably minimal image that can compile curl with gcc-7.

---

This basically gives us a container image that has all of the common Linux libraries plus specially compiled guests (nghttp2, libidn, libpsl).

If you feel you don't want to review this, I'm happy to just commit.